### PR TITLE
HasuraのテーブルをReadOnlyにした

### DIFF
--- a/api/metadata/databases/default/tables/public_bureau.yaml
+++ b/api/metadata/databases/default/tables/public_bureau.yaml
@@ -5,3 +5,25 @@ object_relationships:
   - name: keycloak_group
     using:
       foreign_key_constraint_on: group_id
+select_permissions:
+  - role: user
+    permission:
+      columns:
+        - group_id
+        - name
+        - id
+      filter: {}
+  - role: manager
+    permission:
+      columns:
+        - group_id
+        - name
+        - id
+      filter: {}
+  - role: developper
+    permission:
+      columns:
+        - group_id
+        - name
+        - id
+      filter: {}

--- a/api/metadata/databases/default/tables/public_bureau.yaml
+++ b/api/metadata/databases/default/tables/public_bureau.yaml
@@ -20,7 +20,7 @@ select_permissions:
         - name
         - id
       filter: {}
-  - role: developper
+  - role: developer
     permission:
       columns:
         - group_id

--- a/api/metadata/databases/default/tables/public_department.yaml
+++ b/api/metadata/databases/default/tables/public_department.yaml
@@ -5,3 +5,25 @@ object_relationships:
   - name: keycloak_group
     using:
       foreign_key_constraint_on: group_id
+select_permissions:
+  - role: user
+    permission:
+      columns:
+        - group_id
+        - name
+        - id
+      filter: {}
+  - role: manager
+    permission:
+      columns:
+        - group_id
+        - name
+        - id
+      filter: {}
+  - role: developper
+    permission:
+      columns:
+        - group_id
+        - name
+        - id
+      filter: {}

--- a/api/metadata/databases/default/tables/public_department.yaml
+++ b/api/metadata/databases/default/tables/public_department.yaml
@@ -20,7 +20,7 @@ select_permissions:
         - name
         - id
       filter: {}
-  - role: developper
+  - role: developer
     permission:
       columns:
         - group_id

--- a/api/metadata/databases/default/tables/public_grade.yaml
+++ b/api/metadata/databases/default/tables/public_grade.yaml
@@ -5,3 +5,25 @@ object_relationships:
   - name: keycloak_group
     using:
       foreign_key_constraint_on: group_id
+select_permissions:
+  - role: user
+    permission:
+      columns:
+        - group_id
+        - name
+        - id
+      filter: {}
+  - role: manager
+    permission:
+      columns:
+        - group_id
+        - name
+        - id
+      filter: {}
+  - role: developper
+    permission:
+      columns:
+        - group_id
+        - name
+        - id
+      filter: {}

--- a/api/metadata/databases/default/tables/public_grade.yaml
+++ b/api/metadata/databases/default/tables/public_grade.yaml
@@ -20,7 +20,7 @@ select_permissions:
         - name
         - id
       filter: {}
-  - role: developper
+  - role: developer
     permission:
       columns:
         - group_id

--- a/api/metadata/databases/default/tables/public_group_attribute.yaml
+++ b/api/metadata/databases/default/tables/public_group_attribute.yaml
@@ -5,3 +5,26 @@ object_relationships:
   - name: keycloak_group
     using:
       foreign_key_constraint_on: group_id
+select_permissions:
+  - role: user
+    permission:
+      columns:
+        - group_id
+        - id
+        - name
+        - value
+      filter: {}
+  - role: manager
+    permission:
+      columns:
+        - group_id
+        - name
+        - id
+      filter: {}
+  - role: developper
+    permission:
+      columns:
+        - group_id
+        - name
+        - id
+      filter: {}

--- a/api/metadata/databases/default/tables/public_group_attribute.yaml
+++ b/api/metadata/databases/default/tables/public_group_attribute.yaml
@@ -21,7 +21,7 @@ select_permissions:
         - name
         - id
       filter: {}
-  - role: developper
+  - role: developer
     permission:
       columns:
         - group_id

--- a/api/metadata/databases/default/tables/public_group_role_mapping.yaml
+++ b/api/metadata/databases/default/tables/public_group_role_mapping.yaml
@@ -18,7 +18,7 @@ select_permissions:
         - group_id
         - role_id
       filter: {}
-  - role: developper
+  - role: developer
     permission:
       columns:
         - group_id

--- a/api/metadata/databases/default/tables/public_group_role_mapping.yaml
+++ b/api/metadata/databases/default/tables/public_group_role_mapping.yaml
@@ -5,3 +5,22 @@ object_relationships:
   - name: keycloak_group
     using:
       foreign_key_constraint_on: group_id
+select_permissions:
+  - role: user
+    permission:
+      columns:
+        - group_id
+        - role_id
+      filter: {}
+  - role: manager
+    permission:
+      columns:
+        - group_id
+        - role_id
+      filter: {}
+  - role: developper
+    permission:
+      columns:
+        - group_id
+        - role_id
+      filter: {}

--- a/api/metadata/databases/default/tables/public_keycloak_group.yaml
+++ b/api/metadata/databases/default/tables/public_keycloak_group.yaml
@@ -61,7 +61,7 @@ select_permissions:
         - parent_group
         - realm_id
       filter: {}
-  - role: developper
+  - role: developer
     permission:
       columns:
         - id

--- a/api/metadata/databases/default/tables/public_keycloak_group.yaml
+++ b/api/metadata/databases/default/tables/public_keycloak_group.yaml
@@ -44,3 +44,28 @@ array_relationships:
         table:
           name: user_group_membership
           schema: public
+select_permissions:
+  - role: user
+    permission:
+      columns:
+        - id
+        - name
+        - parent_group
+        - realm_id
+      filter: {}
+  - role: manager
+    permission:
+      columns:
+        - id
+        - name
+        - parent_group
+        - realm_id
+      filter: {}
+  - role: developper
+    permission:
+      columns:
+        - id
+        - name
+        - parent_group
+        - realm_id
+      filter: {}

--- a/api/metadata/databases/default/tables/public_keycloak_role.yaml
+++ b/api/metadata/databases/default/tables/public_keycloak_role.yaml
@@ -34,7 +34,7 @@ select_permissions:
         - realm
         - realm_id
       filter: {}
-  - role: developper
+  - role: developer
     permission:
       columns:
         - client_role

--- a/api/metadata/databases/default/tables/public_keycloak_role.yaml
+++ b/api/metadata/databases/default/tables/public_keycloak_role.yaml
@@ -9,3 +9,40 @@ array_relationships:
         table:
           name: role_attribute
           schema: public
+select_permissions:
+  - role: user
+    permission:
+      columns:
+        - client_role
+        - client
+        - client_realm_constraint
+        - description
+        - id
+        - name
+        - realm
+        - realm_id
+      filter: {}
+  - role: manager
+    permission:
+      columns:
+        - client_role
+        - client
+        - client_realm_constraint
+        - description
+        - id
+        - name
+        - realm
+        - realm_id
+      filter: {}
+  - role: developper
+    permission:
+      columns:
+        - client_role
+        - client
+        - client_realm_constraint
+        - description
+        - id
+        - name
+        - realm
+        - realm_id
+      filter: {}

--- a/api/metadata/databases/default/tables/public_role_attribute.yaml
+++ b/api/metadata/databases/default/tables/public_role_attribute.yaml
@@ -5,3 +5,28 @@ object_relationships:
   - name: keycloak_role
     using:
       foreign_key_constraint_on: role_id
+select_permissions:
+  - role: user
+    permission:
+      columns:
+        - id
+        - name
+        - role_id
+        - value
+      filter: {}
+  - role: manager
+    permission:
+      columns:
+        - id
+        - name
+        - role_id
+        - value
+      filter: {}
+  - role: developper
+    permission:
+      columns:
+        - id
+        - name
+        - role_id
+        - value
+      filter: {}

--- a/api/metadata/databases/default/tables/public_role_attribute.yaml
+++ b/api/metadata/databases/default/tables/public_role_attribute.yaml
@@ -22,7 +22,7 @@ select_permissions:
         - role_id
         - value
       filter: {}
-  - role: developper
+  - role: developer
     permission:
       columns:
         - id

--- a/api/metadata/databases/default/tables/public_user_attribute.yaml
+++ b/api/metadata/databases/default/tables/public_user_attribute.yaml
@@ -22,7 +22,7 @@ select_permissions:
         - user_id
         - value
       filter: {}
-  - role: developper
+  - role: developer
     permission:
       columns:
         - id

--- a/api/metadata/databases/default/tables/public_user_attribute.yaml
+++ b/api/metadata/databases/default/tables/public_user_attribute.yaml
@@ -5,3 +5,28 @@ object_relationships:
   - name: user_entity
     using:
       foreign_key_constraint_on: user_id
+select_permissions:
+  - role: user
+    permission:
+      columns:
+        - id
+        - name
+        - user_id
+        - value
+      filter: {}
+  - role: manager
+    permission:
+      columns:
+        - id
+        - name
+        - user_id
+        - value
+      filter: {}
+  - role: developper
+    permission:
+      columns:
+        - id
+        - name
+        - user_id
+        - value
+      filter: {}

--- a/api/metadata/databases/default/tables/public_user_entity.yaml
+++ b/api/metadata/databases/default/tables/public_user_entity.yaml
@@ -58,7 +58,7 @@ select_permissions:
         - username
         - not_before
       filter: {}
-  - role: developper
+  - role: developer
     permission:
       columns:
         - created_timestamp

--- a/api/metadata/databases/default/tables/public_user_entity.yaml
+++ b/api/metadata/databases/default/tables/public_user_entity.yaml
@@ -23,3 +23,55 @@ array_relationships:
         table:
           name: user_role_mapping
           schema: public
+select_permissions:
+  - role: user
+    permission:
+      columns:
+        - created_timestamp
+        - email_verified
+        - enabled
+        - email
+        - email_constraint
+        - federation_link
+        - first_name
+        - id
+        - last_name
+        - realm_id
+        - service_account_client_link
+        - username
+        - not_before
+      filter: {}
+  - role: manager
+    permission:
+      columns:
+        - created_timestamp
+        - email_verified
+        - enabled
+        - email
+        - email_constraint
+        - federation_link
+        - first_name
+        - id
+        - last_name
+        - realm_id
+        - service_account_client_link
+        - username
+        - not_before
+      filter: {}
+  - role: developper
+    permission:
+      columns:
+        - created_timestamp
+        - email_verified
+        - enabled
+        - email
+        - email_constraint
+        - federation_link
+        - first_name
+        - id
+        - last_name
+        - realm_id
+        - service_account_client_link
+        - username
+        - not_before
+      filter: {}

--- a/api/metadata/databases/default/tables/public_user_group_membership.yaml
+++ b/api/metadata/databases/default/tables/public_user_group_membership.yaml
@@ -21,7 +21,7 @@ select_permissions:
         - group_id
         - user_id
       filter: {}
-  - role: developper
+  - role: developer
     permission:
       columns:
         - group_id

--- a/api/metadata/databases/default/tables/public_user_group_membership.yaml
+++ b/api/metadata/databases/default/tables/public_user_group_membership.yaml
@@ -8,3 +8,22 @@ object_relationships:
   - name: user_entity
     using:
       foreign_key_constraint_on: user_id
+select_permissions:
+  - role: user
+    permission:
+      columns:
+        - group_id
+        - user_id
+      filter: {}
+  - role: manager
+    permission:
+      columns:
+        - group_id
+        - user_id
+      filter: {}
+  - role: developper
+    permission:
+      columns:
+        - group_id
+        - user_id
+      filter: {}

--- a/api/metadata/databases/default/tables/public_user_role_mapping.yaml
+++ b/api/metadata/databases/default/tables/public_user_role_mapping.yaml
@@ -5,3 +5,22 @@ object_relationships:
   - name: user_entity
     using:
       foreign_key_constraint_on: user_id
+select_permissions:
+  - role: user
+    permission:
+      columns:
+        - role_id
+        - user_id
+      filter: {}
+  - role: manager
+    permission:
+      columns:
+        - role_id
+        - user_id
+      filter: {}
+  - role: developper
+    permission:
+      columns:
+        - role_id
+        - user_id
+      filter: {}

--- a/api/metadata/databases/default/tables/public_user_role_mapping.yaml
+++ b/api/metadata/databases/default/tables/public_user_role_mapping.yaml
@@ -18,7 +18,7 @@ select_permissions:
         - role_id
         - user_id
       filter: {}
-  - role: developper
+  - role: developer
     permission:
       columns:
         - role_id


### PR DESCRIPTION
## 対応 Issue

resolve #48

## 概要

User, Manager, DevelopperのHasuraのテーブルをReadOnlyにした

## テスト項目

- [ ] localhost:8082 が立ち上がる
- [ ] http://localhost:8082/console/data/default/schema/public/tables/ここにテーブルの名前_bureauなど/permissions  で確認できる

## URL・スクリーンショット

- http://localhost:8082/console/data/default/schema/public/tables/bureau/permissions
- <img width="1362" alt="スクリーンショット 2023-06-14 午後4 39 29" src="https://github.com/NUTFes/NUTFES-Account/assets/46074208/ab12b6e0-5e1e-41f7-9fec-875767d5e35d">


## 備考

マージしたら比嘉華のタスクにリベースしてやって続きやると良いです！