### PR TITLE
[add] 名前変更ページの実装(#67)

### DIFF
--- a/frontend/src/pages/username.tsx
+++ b/frontend/src/pages/username.tsx
@@ -1,22 +1,92 @@
-import { Button, Typography } from "@mui/material";
+import { Grid, TextField, Stack, Button } from "@mui/material";
 import { NextPage } from "next";
 import { useRouter } from "next/router";
+import { useState } from "react";
 
 import { DetailLayout } from "@/components/layout";
 import { DETAIL_PAGE_CONSTANTS } from "@/constants/detailPage";
 
 export const UserName: NextPage = () => {
   const router = useRouter();
-  const handleClick = (link: string) => {
-    router.push(link).catch((error) => {
-      console.error(error);
-    });
-  };
   const details = DETAIL_PAGE_CONSTANTS.username;
+
+  // TODO: API側から名前を取得するメソッドを作成する
+  const getDefaultName = (): {
+    defaultFirstName: string;
+    defaultLastName: string;
+  } => ({
+    defaultFirstName: "技大",
+    defaultLastName: "太郎",
+  });
+
+  const { defaultFirstName, defaultLastName } = getDefaultName();
+
+  const [firstName, setFirstName] = useState(defaultFirstName);
+  const [lastName, setLastName] = useState(defaultLastName);
+
+  const saveName = () => {
+    console.log(firstName + lastName); // eslint-disable-line no-console
+  };
+
+  const cancell = () => {
+    router.push("/personal-info").catch((err) => console.error(err));
+  };
+
   return (
     <DetailLayout {...details}>
-      <Typography variant="h5">Comming soon UserName Page</Typography>
-      <Button onClick={() => handleClick("/")}>Return to Home</Button>
+      <Grid
+        container
+        alignItems="center"
+        justifyContent="center"
+        direction="column"
+        sx={{
+          px: "24px",
+          mt: "24px",
+        }}
+      >
+        <TextField
+          label="名前"
+          id="firstName"
+          value={firstName}
+          variant="standard"
+          fullWidth
+          margin="normal"
+          onChange={(e) => {
+            setFirstName(e.target.value);
+          }}
+        />
+        <TextField
+          label="苗字"
+          id="lastName"
+          value={lastName}
+          variant="standard"
+          fullWidth
+          margin="normal"
+          onChange={(e) => {
+            setLastName(e.target.value);
+          }}
+        />
+      </Grid>
+      <Stack
+        spacing={2}
+        direction="row"
+        justifyContent="end"
+        sx={{
+          width: 1,
+          mt: "24px",
+          mb: "8px",
+          px: "16px",
+        }}
+      >
+        <Button onClick={cancell}>キャンセル</Button>
+        <Button
+          disabled={lastName === "" && firstName === ""}
+          variant="contained"
+          onClick={saveName}
+        >
+          保存
+        </Button>
+      </Stack>
     </DetailLayout>
   );
 };


### PR DESCRIPTION
## 対応 Issue

resolve #67 

## 概要
名前変更ページの実装

<!-- 開発内容の概要を記載 -->
## 名前変更ページの実装 19506b0b0b680abb2cf6fcbf8b839acdf05ea166
- [MUI TextField](https://mui.com/material-ui/react-text-field/)を利用しました。

## テスト項目

- [x] UI・UXは適切か
現状名前・苗字しか入れらないが適切か
![image](https://github.com/NUTFes/NUTFES-Account/assets/50622120/ec5fcdc5-474b-4d49-bbd3-f434d1d9ea58)

- [ ] コードは適切か
改変できるところがあれば、改変する

- [x] 動作確認
- 名前・苗字を入力して、保存した際に苗字+名前でコンソールが出力されるか
- 空値の時は、ボタンが押せないか
- キャンセルは`/personal-info`に戻るか

## URL・スクリーンショット

- <!-- URLを記載 -->
- http://localhost:12345/username
- <!-- スクリーンショットを添付 -->
上の画像を参照してください。

## 備考
TODOとして、DB側から名前を取得するメソッドを作成する機能を今後実装する。
